### PR TITLE
fix: use FACTORY_PAT in auto-tag to trigger publish

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FACTORY_PAT }}
 
       - name: Read version and create tag
         run: |


### PR DESCRIPTION
## Summary
- Tags pushed with `GITHUB_TOKEN` don't trigger other workflows (GitHub limitation)
- Use `FACTORY_PAT` in auto-tag checkout so the tag push triggers `publish.yml`

## Test plan
- [ ] After merge: auto-tag runs (tag already exists, so it skips — no-op)
- [ ] Next version bump: auto-tag creates tag → publish fires