### PR TITLE
chore: fill conda-forge recipe SHA256 for v0.2.4

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,8 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/o/obsidian-export/obsidian_export-${{ version }}.tar.gz
-  # TODO: fill after v0.2.4 is published to PyPI
-  sha256: PLACEHOLDER_FILL_AFTER_PYPI_PUBLISH
+  sha256: 7a0ff610c9182917096e2d0477692c3571d6f537b3c8d22142fb7dcad2315d77
 
 build:
   noarch: python


### PR DESCRIPTION
## Summary

- Fill the SHA256 placeholder in `recipe/recipe.yaml` with the actual sdist hash from PyPI v0.2.4: `7a0ff610c9182917096e2d0477692c3571d6f537b3c8d22142fb7dcad2315d77`

Recipe is now ready to submit to `conda-forge/staged-recipes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)