### PR TITLE
fix: sync conda-forge recipe with staged-recipes PR

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "0.2.4"
+  python_min: "3.12"
 
 package:
   name: obsidian-export
@@ -20,25 +21,38 @@ build:
 
 requirements:
   host:
-    - python >=3.12
+    - python ${{ python_min }}.*
     - pip
     - hatchling
   run:
-    - python >=3.12
+    - python >=${{ python_min }}
     - pyyaml >=6.0,<7
     - click >=8.0,<9
     - pandoc >=3.5
     - tectonic >=0.15
     - librsvg >=2.58
 
-test:
-  imports:
-    - obsidian_export
-  commands:
-    - obsidian-export --help
+tests:
+  - python:
+      imports:
+        - obsidian_export
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - obsidian-export --help
 
 about:
-  home: https://github.com/neuralsignal/obsidian-export
+  homepage: https://github.com/neuralsignal/obsidian-export
+  repository: https://github.com/neuralsignal/obsidian-export
+  summary: Convert Obsidian-flavored Markdown to PDF and DOCX
+  description: |
+    Convert Obsidian-flavored Markdown to PDF and DOCX. Handles wikilinks,
+    embeds, callouts, Mermaid diagrams, and frontmatter via a 5-stage pipeline.
+    When installed from conda-forge, all system dependencies (pandoc, tectonic,
+    librsvg) are included automatically.
   license: MIT
   license_file: LICENSE
-  summary: Convert Obsidian-flavored Markdown to PDF and DOCX
+
+extra:
+  recipe-maintainers:
+    - neuralsignal


### PR DESCRIPTION
## Summary

- Add `python_min` context variable (`"3.12"`) per conda-forge best practices for `noarch: python` recipes
- Use `python_min` in host (`${{ python_min }}.*`), run (`>=${{ python_min }}`), and tests (`python_version: ${{ python_min }}.*`) sections
- Fix `test:` (singular) → `tests:` (plural list format) for v1 recipe schema
- Add missing `homepage`, `repository`, `description`, and `extra.recipe-maintainers` fields

Now matches the staged-recipes PR exactly: https://github.com/conda-forge/staged-recipes/pull/32526

🤖 Generated with [Claude Code](https://claude.com/claude-code)