### PR TITLE
feat: add dark factory auto-fix loop

### DIFF
--- a/.github/workflows/factory-orchestrator.yml
+++ b/.github/workflows/factory-orchestrator.yml
@@ -28,7 +28,8 @@ jobs:
             --json number,labels \
             --jq '[.[] | select(
               (.labels | map(.name) | index("status:in-progress") | not) and
-              (.labels | map(.name) | index("status:pr-created") | not)
+              (.labels | map(.name) | index("status:pr-created") | not) and
+              (.labels | map(.name) | index("status:pr-draft") | not)
             ) | .number] | .[]')
 
           if [ -z "$ISSUES" ]; then
@@ -124,8 +125,12 @@ jobs:
 
           QUEUED=$(gh issue list --repo "$REPO" --label "claude:implement" --state open --json number --jq 'length')
           IN_PROGRESS=$(gh issue list --repo "$REPO" --label "status:in-progress" --state open --json number --jq 'length')
+          PR_DRAFT=$(gh issue list --repo "$REPO" --label "status:pr-draft" --state open --json number --jq 'length')
           PR_CREATED=$(gh issue list --repo "$REPO" --label "status:pr-created" --state open --json number --jq 'length')
           BLOCKED=$(gh issue list --repo "$REPO" --label "status:blocked" --state open --json number --jq 'length')
+          AUTOFIX_1=$(gh issue list --repo "$REPO" --label "autofix:1" --state open --json number --jq 'length')
+          AUTOFIX_2=$(gh issue list --repo "$REPO" --label "autofix:2" --state open --json number --jq 'length')
+          AUTOFIX_3=$(gh issue list --repo "$REPO" --label "autofix:3" --state open --json number --jq 'length')
 
           cat > /tmp/dashboard.md << EOF
           ## Factory Status ($(date -u '+%Y-%m-%d %H:%M UTC'))
@@ -134,7 +139,9 @@ jobs:
           |--------|-------|
           | Queued (claude:implement) | $QUEUED |
           | In Progress | $IN_PROGRESS |
+          | Draft PR (CI pending) | $PR_DRAFT |
           | PR Created (awaiting review) | $PR_CREATED |
+          | Auto-fix (attempt 1/2/3) | $AUTOFIX_1 / $AUTOFIX_2 / $AUTOFIX_3 |
           | Blocked | $BLOCKED |
 
           *Updated by factory-orchestrator (run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))*

--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --max-turns 50 --allowedTools Read,Write,Edit,Glob,Grep,Bash"
+          claude_args: "--model claude-opus-4-6 --max-turns 50 --allowedTools Read,Write,Edit,Glob,Grep,Bash"
           prompt: |
             You are implementing a GitHub issue as a code change.
             Read CLAUDE.md for project conventions, build commands, and standards.
@@ -99,6 +99,7 @@ jobs:
           # Check if branch has commits ahead of main
           if git log origin/main..${{ steps.branch.outputs.branch }} --oneline | head -1 | grep -q .; then
             gh pr create \
+              --draft \
               --title "$(echo '${{ github.event.issue.title }}' | head -c 70)" \
               --body "Closes #${{ github.event.issue.number }}
 
@@ -118,7 +119,7 @@ jobs:
             gh issue edit ${{ github.event.issue.number }} \
               --repo ${{ github.repository }} \
               --remove-label status:in-progress \
-              --add-label status:pr-created
+              --add-label status:pr-draft
           else
             echo "No commits on branch -- nothing to create PR for."
           fi

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -1,0 +1,278 @@
+name: PR Auto-Fix
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+  id-token: write
+
+concurrency:
+  group: autofix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    name: Auto-fix CI failures
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find associated PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_JSON=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --head "$BRANCH" \
+            --state open \
+            --json number,headRefName \
+            --jq '.[0]')
+
+          if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+            echo "No open PR found for branch $BRANCH. Skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Found PR #$PR_NUMBER for branch $BRANCH"
+
+      - name: Check retry count
+        if: steps.pr.outputs.skip != 'true'
+        id: retry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          LABELS=$(gh pr view "$PR_NUMBER" \
+            --repo ${{ github.repository }} \
+            --json labels \
+            --jq '[.labels[].name] | join(",")')
+
+          ATTEMPT=1
+          if echo "$LABELS" | grep -q "autofix:3"; then
+            echo "Already at max retries (autofix:3). Marking blocked."
+            echo "exhausted=true" >> $GITHUB_OUTPUT
+            exit 0
+          elif echo "$LABELS" | grep -q "autofix:2"; then
+            ATTEMPT=3
+          elif echo "$LABELS" | grep -q "autofix:1"; then
+            ATTEMPT=2
+          fi
+
+          echo "attempt=$ATTEMPT" >> $GITHUB_OUTPUT
+          echo "exhausted=false" >> $GITHUB_OUTPUT
+          echo "Auto-fix attempt $ATTEMPT"
+
+      - name: Mark blocked (max retries)
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+
+          # Find linked issue from PR body ("Closes #N")
+          ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" \
+            --repo ${{ github.repository }} \
+            --json body \
+            --jq '.body' | grep -oP 'Closes #\K\d+' | head -1)
+
+          gh pr comment "$PR_NUMBER" \
+            --repo ${{ github.repository }} \
+            --body "Auto-fix exhausted after 3 attempts. Marking as blocked for human review.
+
+          [Failed CI run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})"
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue edit "$ISSUE_NUMBER" \
+              --repo ${{ github.repository }} \
+              --remove-label "status:pr-draft" \
+              --add-label "status:blocked" 2>/dev/null || true
+          fi
+
+      - name: Checkout PR branch
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Set up pixi
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          cache: true
+
+      - name: Install system deps for Puppeteer
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+            libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 \
+            libpango-1.0-0 libcairo2 libasound2t64
+
+      - name: Set up mermaid-cli
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        run: pixi run setup-mmdc
+
+      - name: Download CI failure logs
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID="${{ github.event.workflow_run.id }}"
+
+          # Get failed job logs
+          gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure") | {name: .name, id: .id}' > /tmp/failed_jobs.json
+
+          echo "Failed jobs:"
+          cat /tmp/failed_jobs.json
+
+          # Download logs for each failed job
+          echo "" > /tmp/ci_failure_logs.txt
+          for JOB_ID in $(jq -r '.id' /tmp/failed_jobs.json); do
+            JOB_NAME=$(jq -r "select(.id == $JOB_ID) | .name" /tmp/failed_jobs.json)
+            echo "=== Job: $JOB_NAME (ID: $JOB_ID) ===" >> /tmp/ci_failure_logs.txt
+            gh api "repos/${{ github.repository }}/actions/jobs/${JOB_ID}/logs" >> /tmp/ci_failure_logs.txt 2>/dev/null || true
+            echo "" >> /tmp/ci_failure_logs.txt
+          done
+
+          # Truncate to last 2000 lines to stay within prompt limits
+          tail -n 2000 /tmp/ci_failure_logs.txt > /tmp/ci_logs_truncated.txt
+          mv /tmp/ci_logs_truncated.txt /tmp/ci_failure_logs.txt
+
+      - name: Apply auto-fix label
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ATTEMPT="${{ steps.retry.outputs.attempt }}"
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+
+          # Remove previous autofix label if upgrading
+          if [ "$ATTEMPT" -eq 2 ]; then
+            gh pr edit "$PR_NUMBER" --repo ${{ github.repository }} --remove-label "autofix:1" 2>/dev/null || true
+          elif [ "$ATTEMPT" -eq 3 ]; then
+            gh pr edit "$PR_NUMBER" --repo ${{ github.repository }} --remove-label "autofix:2" 2>/dev/null || true
+          fi
+
+          gh pr edit "$PR_NUMBER" --repo ${{ github.repository }} --add-label "autofix:$ATTEMPT"
+
+      - name: Fix CI failures with Claude
+        if: steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6 --max-turns 30 --allowedTools Read,Write,Edit,Glob,Grep,Bash"
+          prompt: |
+            You are fixing CI failures on a pull request.
+            Read CLAUDE.md for project conventions, build commands, and standards.
+
+            This is auto-fix attempt ${{ steps.retry.outputs.attempt }} of 3.
+
+            PR: #${{ steps.pr.outputs.pr_number }}
+            Branch: ${{ github.event.workflow_run.head_branch }}
+            Failed CI run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+
+            CI failure logs:
+            ```
+            $(cat /tmp/ci_failure_logs.txt)
+            ```
+
+            Steps:
+            1. Read CLAUDE.md to understand the project's build/test/lint commands.
+            2. Analyze the CI failure logs above to identify what failed and why.
+            3. Fix the issues in the code (lint errors, test failures, type errors, etc.).
+            4. Run the project's test command: pixi run test-cov
+            5. Run lint/format: pixi run lint && pixi run format-check
+            6. Commit and push:
+               git add -A && git commit -m "fix: auto-fix CI failures (attempt ${{ steps.retry.outputs.attempt }})"
+               git push origin ${{ github.event.workflow_run.head_branch }}
+
+            IMPORTANT:
+            - Never modify .github/workflows/ files.
+            - Focus ONLY on fixing the CI failures. Do not refactor or improve unrelated code.
+            - If you cannot fix the issue, write a clear explanation to /tmp/blocked.md.
+
+      - name: Comment on failure
+        if: failure() && steps.pr.outputs.skip != 'true' && steps.retry.outputs.exhausted != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          ATTEMPT="${{ steps.retry.outputs.attempt }}"
+
+          if [ -f /tmp/blocked.md ]; then
+            gh pr comment "$PR_NUMBER" \
+              --repo ${{ github.repository }} \
+              --body "$(cat /tmp/blocked.md)
+
+          (auto-fix attempt $ATTEMPT)"
+          else
+            gh pr comment "$PR_NUMBER" \
+              --repo ${{ github.repository }} \
+              --body "Auto-fix attempt $ATTEMPT failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          fi
+
+  ready:
+    name: Promote draft PR on CI pass
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'claude/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and promote draft PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_JSON=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --head "$BRANCH" \
+            --state open \
+            --json number,isDraft \
+            --jq '.[0]')
+
+          if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+            echo "No open PR found for branch $BRANCH. Skipping."
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
+
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "PR #$PR_NUMBER is already ready for review. Skipping."
+            exit 0
+          fi
+
+          echo "Promoting PR #$PR_NUMBER from draft to ready for review..."
+          gh pr ready "$PR_NUMBER" --repo ${{ github.repository }}
+
+          # Find linked issue from PR body ("Closes #N")
+          ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" \
+            --repo ${{ github.repository }} \
+            --json body \
+            --jq '.body' | grep -oP 'Closes #\K\d+' | head -1)
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            gh issue edit "$ISSUE_NUMBER" \
+              --repo ${{ github.repository }} \
+              --remove-label "status:pr-draft" \
+              --add-label "status:pr-created" 2>/dev/null || true
+          fi
+
+          echo "PR #$PR_NUMBER promoted to ready for review."

--- a/.github/workflows/pr-docs-check.yml
+++ b/.github/workflows/pr-docs-check.yml
@@ -2,7 +2,7 @@ name: PR Documentation Check
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,11 @@ Non-negotiable principles. Violating these is a bug.
 | `status:triaged` | Issue has been triaged |
 | `status:in-progress` | Claude is working on this |
 | `status:pr-created` | PR created, awaiting review |
+| `status:pr-draft` | Draft PR created, CI pending |
 | `status:blocked` | Implementation blocked (see comments) |
+| `autofix:1` | First auto-fix attempt |
+| `autofix:2` | Second auto-fix attempt |
+| `autofix:3` | Third (final) auto-fix attempt |
 | `source:dep-audit` | Created by dependency audit agent |
 | `source:security-scan` | Created by security scan agent |
 | `source:code-quality` | Created by code quality agent |


### PR DESCRIPTION
## Summary

- **New `pr-autofix.yml` workflow**: Automatically fixes CI failures on agent-created PRs (`claude/` branches). Downloads failure logs, runs Claude Sonnet to fix code, pushes fixes — up to 3 attempts with `autofix:1/2/3` label tracking. Promotes draft PRs to ready-for-review when CI passes.
- **Draft PR quality gate**: `issue-implement` now creates **draft** PRs (`status:pr-draft`). Humans only see PRs after CI passes and the draft is promoted to ready-for-review.
- **Model upgrade**: `issue-implement` model changed from `claude-sonnet-4-6` to `claude-opus-4-6` (aligns with kit default).
- **`pr-docs-check`** now fires on `ready_for_review` events (catches promoted drafts).
- **`factory-orchestrator`** excludes `status:pr-draft` from orphan sweep; dashboard adds draft PR and autofix attempt counts.
- **CLAUDE.md** label taxonomy updated with 4 new labels.
- **Labels created** on repo via `setup-labels.sh`.

## Label state machine

```
claude:implement → status:in-progress → status:pr-draft → [CI pass] → status:pr-created
                                                         → [CI fail] → autofix:1 → ... → autofix:3 → status:blocked
```

## Test plan

- [ ] Create a test issue with a deliberate lint violation, label `claude:implement`
- [ ] Verify draft PR created (not visible as "ready")
- [ ] Verify CI runs and fails
- [ ] Verify `pr-autofix` triggers, reads logs, fixes, pushes
- [ ] Verify CI re-runs and passes
- [ ] Verify draft promoted to ready-for-review
- [ ] Verify `pr-code-review` and `pr-docs-check` fire on the now-ready PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)