### PR TITLE
fix: use FACTORY_PAT for PR creation to bypass cascade suppression

### DIFF
--- a/.github/workflows/issue-implement.yml
+++ b/.github/workflows/issue-implement.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Create PR
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.FACTORY_PAT }}
         run: |
           # Check if branch has commits ahead of main
           if git log origin/main..${{ steps.branch.outputs.branch }} --oneline | head -1 | grep -q .; then


### PR DESCRIPTION
## Summary

- `issue-implement` "Create PR" step now uses `FACTORY_PAT` instead of `GITHUB_TOKEN`
- Without this, `GITHUB_TOKEN`-created PRs suppress `pull_request` events, so **CI never runs** on agent PRs
- This broke the entire auto-fix loop: `pr-autofix` triggers on `workflow_run` completion of CI — if CI never fires, nothing downstream fires

One-line change: `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` → `GH_TOKEN: ${{ secrets.FACTORY_PAT }}` in the "Create PR" step.

## Test plan

- [ ] After merge, re-trigger issue #18 (remove and re-add `claude:implement`)
- [ ] Verify: draft PR created → CI runs → auto-fix or promotion fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)