### PR TITLE
fix: remove tectonic/librsvg from conda-forge run deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Convert Obsidian-flavored Markdown to PDF and DOCX. Handles wikilinks, embeds, c
 
 ### conda-forge (recommended)
 
-Installs obsidian-export with all required system dependencies (pandoc, tectonic, librsvg) in one command:
+Installs obsidian-export with pandoc included automatically. You must separately install [tectonic](https://tectonic-typesetting.github.io/) >= 0.15 and [librsvg](https://wiki.gnome.org/Projects/LibRsvg) (not yet available on all platforms via conda-forge). Run `obsidian-export doctor` to check.
 
 ```bash
 conda install -c conda-forge obsidian-export

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,8 +27,6 @@ requirements:
     - pyyaml >=6.0,<7
     - click >=8.0,<9
     - pandoc >=3.5
-    - tectonic >=0.15
-    - librsvg >=2.58
 
 tests:
   - python:
@@ -46,8 +44,9 @@ about:
   description: |
     Convert Obsidian-flavored Markdown to PDF and DOCX. Handles wikilinks,
     embeds, callouts, Mermaid diagrams, and frontmatter via a 5-stage pipeline.
-    When installed from conda-forge, all system dependencies (pandoc, tectonic,
-    librsvg) are included automatically.
+    When installed from conda-forge, pandoc is included automatically.
+    Tectonic and librsvg must be installed separately (not yet available on
+    all platforms via conda-forge). Run ``obsidian-export doctor`` to check.
   license: MIT
   license_file: LICENSE
 


### PR DESCRIPTION
librsvg has no win-64 build on conda-forge, and tectonic >=0.15 doesn't exist (latest is 0.1.12). Removing from run deps so the noarch package resolves on all platforms. Users install separately; `obsidian-export doctor` checks for them at runtime.