### PR TITLE
fix: pr-code-review needs pull-requests write to post reviews

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     steps:


### PR DESCRIPTION
## Summary

- Change `pull-requests: read` to `pull-requests: write` in `pr-code-review.yml` so the code-review plugin can actually post reviews (with read-only, all review posts are denied — ~$1.60 wasted per run)

## Test plan

- [ ] Verify PR code review workflow posts reviews successfully on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)