### PR TITLE
fix: resolve relative config_dir paths to absolute before joining

### DIFF
--- a/obsidian_export/config.py
+++ b/obsidian_export/config.py
@@ -90,6 +90,9 @@ def _load_default_yaml() -> dict:
 
 def _build_config(raw: dict, config_dir: Path | None) -> ConvertConfig:
     """Build ConvertConfig from a raw dict. Resolve relative paths if config_dir given."""
+    if config_dir is not None and not config_dir.is_absolute():
+        config_dir = config_dir.resolve()
+
     mermaid_raw = raw["mermaid"]
     mmdc_bin_raw = Path(mermaid_raw["mmdc_bin"])
     if config_dir and not mmdc_bin_raw.is_absolute():
@@ -108,12 +111,12 @@ def _build_config(raw: dict, config_dir: Path | None) -> ConvertConfig:
     # Resolve relative style_dir against config_dir (same as mmdc_bin)
     style_dir_raw = style_raw["style_dir"]
     if style_dir_raw and config_dir and not Path(style_dir_raw).is_absolute():
-        style_dir_raw = str(config_dir / style_dir_raw)
+        style_dir_raw = str((config_dir / style_dir_raw).resolve())
 
     # Resolve logo path relative to config_dir if non-empty and not absolute
     logo_raw = style_raw["logo"]
     if logo_raw and config_dir and not Path(logo_raw).is_absolute():
-        logo_raw = str(config_dir / logo_raw)
+        logo_raw = str((config_dir / logo_raw).resolve())
 
     # Parse brand_colors: dict {name: [r,g,b]} -> tuple of (name, r, g, b)
     brand_colors_raw = style_raw.get("brand_colors", {}) or {}


### PR DESCRIPTION
## Summary

- `load_config()` accepts a relative path (e.g. `--config profiles/sanoptis.yaml`), making `config_dir` relative
- Joining relative `config_dir` with relative sub-paths like `../styles/logo.png` produces non-normalised paths (e.g. `profiles/../styles/logo.png`)
- tectonic runs from a temp directory and cannot resolve these relative paths — conversion fails with _"Unable to load picture or PDF file"_

## Fix

- Resolve `config_dir` to absolute at the top of `_build_config()` (before any path joins)
- Call `.resolve()` on the joined `logo` and `style_dir` paths for full normalisation

## Test plan

- [ ] Confirm existing tests still pass (`pixi run pytest`)
- [ ] Manual smoke test: run `convert.py --config profiles/sanoptis.yaml` from a directory other than the skill root — PDF generates correctly with logo in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)