### PR TITLE
fix: upgrade claude workflow permissions and turn limits

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -18,10 +18,13 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read
     steps:
@@ -34,5 +37,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 30
           additional_permissions: |
             actions: read

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: "--model claude-haiku-4-5-20251001 --max-turns 5 --allowedTools Bash,Read,Write,Glob,Grep"
+          claude_args: "--model claude-haiku-4-5-20251001 --max-turns 10 --allowedTools Bash,Read,Write,Glob,Grep"
           prompt: |
             You are an issue triage assistant.
             Read the CLAUDE.md file using the Read tool for full context on labels and conventions.


### PR DESCRIPTION
## Summary
- **claude-mention.yml**: Upgrade GITHUB_TOKEN permissions to write (belt-and-suspenders with OAuth token), add concurrency group, add model (sonnet-4-6) and max-turns (30) config
- **issue-triage.yml**: Increase max-turns from 5 to 10 to fix `error_max_turns` failures (confirmed in run #22869056690)

## Context
The OAuth token handles writes independently, but GITHUB_TOKEN write permissions ensure both auth paths work. Issue triage needs ~6-7 turns (read CLAUDE.md, analyze, apply labels, write comment, post comment) so 5 was too tight.

## Test plan
- [ ] Open a test issue to verify triage completes within 10 turns
- [ ] Mention @claude in an issue to verify branch/PR creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)