### PR TITLE
docs: sync documentation with codebase

### DIFF
--- a/docs/concepts/syntax-support.md
+++ b/docs/concepts/syntax-support.md
@@ -22,7 +22,7 @@ Wikilinks are converted to plain text. The display text is preserved when availa
 
 ## Embed Resolution
 
-Embeds (`![[filename]]`) are recursively resolved — the referenced file's content is inlined at the embed location. Circular references are detected and reported as warnings.
+Embeds (`![[filename]]`) are recursively resolved — the referenced file's content is inlined at the embed location. Circular references are detected and raise a `CircularEmbedError`.
 
 ## Callout Styles
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -17,8 +17,8 @@ Configuration is merged on top of built-in defaults. You only need to specify th
 ### CLI
 
 ```bash
-# Use a config file
-obsidian-export convert --input note.md --format pdf --output note.pdf --config my_config.yaml
+# Use a config file (pass the file path as --profile)
+obsidian-export convert --input note.md --format pdf --output note.pdf --profile my_config.yaml
 
 # Use a named profile
 obsidian-export convert --input note.md --format pdf --output note.pdf --profile my_brand
@@ -43,11 +43,13 @@ config = default_config()
 mermaid:
   mmdc_bin: "mmdc"          # Path to Mermaid CLI binary
   scale: 3                  # PNG render scale
+  puppeteer_config: null    # Optional path to puppeteer config JSON
 
 obsidian:
   wikilink_strategy: "text"           # How to handle [[wikilinks]]
   url_strategy: "footnote_long"       # bare URL handling: keep|footnote_long|footnote_all|strip
   url_length_threshold: 60            # URL length for footnote_long strategy
+  max_embed_depth: 10                 # Maximum recursive embed depth
 
 pandoc:
   from_format: "gfm-tex_math_dollars+footnotes" # Pandoc input format
@@ -117,6 +119,7 @@ Controls Mermaid diagram rendering. Requires [mermaid-cli](https://github.com/me
 |-------|------|-------------|
 | `mmdc_bin` | string | Path to the mmdc binary |
 | `scale` | integer | PNG render scale factor |
+| `puppeteer_config` | string or null | Path to a Puppeteer config JSON file (optional) |
 
 ### `obsidian`
 
@@ -127,6 +130,7 @@ Controls Obsidian-specific syntax handling.
 | `wikilink_strategy` | string | How to convert wikilinks (`text`) |
 | `url_strategy` | string | URL handling: `keep`, `footnote_long`, `footnote_all`, `strip` |
 | `url_length_threshold` | integer | URL length threshold for `footnote_long` strategy |
+| `max_embed_depth` | integer | Maximum recursive depth for `![[embed]]` resolution |
 
 ### `pandoc`
 

--- a/docs/user-guide/profiles.md
+++ b/docs/user-guide/profiles.md
@@ -55,4 +55,4 @@ Pass the profile name to the `convert` command:
 obsidian-export convert --input my_note.md --format pdf --output my_note.pdf --profile my_brand
 ```
 
-When no `--profile` is specified, the built-in defaults are used. If a `--config` file is provided instead, its values override the defaults directly without involving the profile system.
+When no `--profile` is specified, the built-in defaults are used. You can also pass a path to a config YAML file directly to `--profile` — if the value is an existing file path, it is loaded as a config file rather than looked up as a profile name.


### PR DESCRIPTION
## Summary

Automated documentation update triggered by source code changes.

## What changed

Documentation pages in `docs/` were updated to match the current state of the codebase.

## Test plan

- [ ] `mkdocs build --strict` passes
- [ ] All nav links resolve
- [ ] API reference reflects current code
