### PR TITLE
feat: code_fontsize config + fvextra line-wrapping + ragged2e table hyphenation

### DIFF
--- a/obsidian_export/assets/filters/fix_tables.lua
+++ b/obsidian_export/assets/filters/fix_tables.lua
@@ -29,7 +29,7 @@ local function col_spec(align)
   elseif align == pandoc.AlignCenter then
     return ">{\\centering\\arraybackslash}X"
   else
-    return ">{\\raggedright\\arraybackslash}X"
+    return ">{\\RaggedRight\\arraybackslash}X"
   end
 end
 

--- a/obsidian_export/assets/styles/default/header.tex
+++ b/obsidian_export/assets/styles/default/header.tex
@@ -13,8 +13,9 @@
 % Nicer table rules
 \usepackage{{booktabs}}
 
-% Page-breaking tables with equal-width wrapping columns
+% Page-breaking tables with equal-width wrapping columns; ragged2e for hyphenation in cells
 \usepackage{{xltabular}}
+\usepackage{{ragged2e}}
 
 % Unicode math symbols — XeTeX resolves from unicode-math font automatically
 \usepackage{{fontspec}}
@@ -41,6 +42,7 @@
   before skip=12pt,after skip=12pt
 }}
 
+{code_block}
 {brand_colors_block}
 {heading_styles_block}
 {title_style_block}

--- a/obsidian_export/config.py
+++ b/obsidian_export/config.py
@@ -68,6 +68,7 @@ class StyleConfig:
     urlcolor: str
     line_spacing: float
     table_fontsize: str
+    code_fontsize: str
     image_max_height_ratio: float
     url_footnote_threshold: int
     header_left: str
@@ -189,6 +190,7 @@ def _build_style_config(raw: dict[str, Any], config_dir: Path | None) -> StyleCo
         urlcolor=raw["urlcolor"],
         line_spacing=float(raw["line_spacing"]),
         table_fontsize=raw["table_fontsize"],
+        code_fontsize=raw["code_fontsize"],
         image_max_height_ratio=float(raw["image_max_height_ratio"]),
         url_footnote_threshold=int(raw["url_footnote_threshold"]),
         header_left=raw["header_left"],

--- a/obsidian_export/defaults/default.yaml
+++ b/obsidian_export/defaults/default.yaml
@@ -26,6 +26,7 @@ style:
   urlcolor: "NavyBlue"
   line_spacing: 1.0
   table_fontsize: "small"
+  code_fontsize: "footnotesize"
   image_max_height_ratio: 0.40
   url_footnote_threshold: 60
   header_left: ""

--- a/obsidian_export/pipeline/latex_header.py
+++ b/obsidian_export/pipeline/latex_header.py
@@ -33,6 +33,7 @@ def render_header(style: StyleConfig, template_path: Path, title: str) -> str:
     brand_colors_block = _build_brand_colors_block(style.brand_colors)
     heading_styles_block = _build_heading_styles_block(style.heading_styles)
     title_style_block = _build_title_style_block(style.title_style)
+    code_block = _build_code_block(style.code_fontsize)
 
     cc = style.callout_colors
     return template.format(
@@ -56,6 +57,7 @@ def render_header(style: StyleConfig, template_path: Path, title: str) -> str:
         brand_colors_block=brand_colors_block,
         heading_styles_block=heading_styles_block,
         title_style_block=title_style_block,
+        code_block=code_block,
     )
 
 
@@ -184,6 +186,17 @@ def _build_title_style_block(title_style: TitleStyle | None) -> str:
     lines.append("}")
     lines.append("\\makeatother")
     return "\n".join(lines)
+
+
+def _build_code_block(code_fontsize: str) -> str:
+    """Generate fvextra setup for code block line-wrapping and font size control."""
+    cmd = f"\\{code_fontsize}"
+    return (
+        "\\usepackage{fvextra}\n"
+        f"\\fvset{{breaklines=true, fontsize={cmd}}}\n"
+        f"\\DefineVerbatimEnvironment{{verbatim}}{{Verbatim}}"
+        f"{{breaklines=true, fontsize={cmd}}}"
+    )
 
 
 def _build_header_footer_block(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,7 @@ VALID_DATA = {
         "urlcolor": "NavyBlue",
         "line_spacing": 1.0,
         "table_fontsize": "small",
+        "code_fontsize": "footnotesize",
         "image_max_height_ratio": 0.40,
         "url_footnote_threshold": 60,
         "header_left": "",
@@ -133,6 +134,7 @@ def test_style_config_loaded(tmp_path: Path) -> None:
     assert result.style.urlcolor == "NavyBlue"
     assert result.style.line_spacing == 1.0
     assert result.style.table_fontsize == "small"
+    assert result.style.code_fontsize == "footnotesize"
     assert result.style.image_max_height_ratio == 0.40
     assert result.style.url_footnote_threshold == 60
     assert result.style.mainfont == ""
@@ -191,6 +193,19 @@ def test_default_config_returns_convert_config() -> None:
     assert result.style.fontsize == "10pt"
     assert result.mermaid.scale == 3
     assert result.obsidian.max_embed_depth == 10
+
+
+def test_default_config_code_fontsize() -> None:
+    result = default_config()
+    assert result.style.code_fontsize == "footnotesize"
+
+
+def test_code_fontsize_override(tmp_path: Path) -> None:
+    partial = {"style": {"code_fontsize": "small"}}
+    cfg = _write_config(tmp_path, partial)
+    result = load_config(cfg)
+    assert result.style.code_fontsize == "small"
+    assert result.style.table_fontsize == "small"  # default unchanged
 
 
 # ── deep merge ──────────────────────────────────────────────────────────────

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,6 +28,7 @@ def _make_style(
         urlcolor="blue",
         line_spacing=1.0,
         table_fontsize="10pt",
+        code_fontsize="footnotesize",
         image_max_height_ratio=0.4,
         url_footnote_threshold=60,
         header_left="",

--- a/tests/test_latex_header.py
+++ b/tests/test_latex_header.py
@@ -8,6 +8,7 @@ import pytest
 from obsidian_export.config import CalloutColors, HeadingStyle, StyleConfig, TitleStyle, default_config
 from obsidian_export.pipeline.latex_header import (
     _build_brand_colors_block,
+    _build_code_block,
     _build_font_block,
     _build_header_footer_block,
     _build_heading_styles_block,
@@ -93,6 +94,29 @@ class TestBuildFontBlock:
     def test_injection_in_monofont_escaped(self) -> None:
         result = _build_font_block("", "", "font$hack")
         assert "\\$" in result
+
+
+class TestBuildCodeBlock:
+    def test_contains_fvextra(self) -> None:
+        result = _build_code_block("footnotesize")
+        assert "\\usepackage{fvextra}" in result
+
+    def test_contains_breaklines(self) -> None:
+        result = _build_code_block("footnotesize")
+        assert "breaklines=true" in result
+
+    def test_fontsize_cmd_in_fvset(self) -> None:
+        result = _build_code_block("footnotesize")
+        assert "\\footnotesize" in result
+
+    def test_fontsize_cmd_small(self) -> None:
+        result = _build_code_block("small")
+        assert "\\small" in result
+        assert "\\footnotesize" not in result
+
+    def test_defines_verbatim_environment(self) -> None:
+        result = _build_code_block("footnotesize")
+        assert "\\DefineVerbatimEnvironment{verbatim}" in result
 
 
 class TestBuildLineSpacingBlock:


### PR DESCRIPTION
## Summary

- **`code_fontsize` config field** — new `StyleConfig` field (mirrors `table_fontsize` pattern); default `"footnotesize"` in `default.yaml`; overridable per profile
- **fvextra line-wrapping** — `_build_code_block()` in `latex_header.py` generates `\usepackage{fvextra}` + `\fvset{breaklines=true, fontsize=\<code_fontsize>}` + `\DefineVerbatimEnvironment{verbatim}{Verbatim}{...}` covering both syntax-highlighted (`Highlighting`) and plain `verbatim` blocks
- **ragged2e table hyphenation** — `\usepackage{ragged2e}` in `header.tex`; `fix_tables.lua` `col_spec()` switches `\raggedright` → `\RaggedRight` so German compound words (Schwabmünchen, Schrobenhausen) can hyphenate in narrow xltabular X columns

## Test plan

- [x] `TestBuildCodeBlock` (5 tests) in `test_latex_header.py` — fvextra, breaklines, footnotesize cmd, small cmd, verbatim env
- [x] `test_default_config_code_fontsize` and `test_code_fontsize_override` in `test_config.py`
- [x] `_make_style()` in `test_init.py` updated with `code_fontsize="footnotesize"`
- [x] All 421 tests pass, 1 skip (real-mmdc property test)
- [x] Full PDF build verified — SQL code blocks wrap at page boundary; code renders in footnotesize; table cells hyphenate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)