### PR TITLE
[security-scan] LaTeX injection via heading/title style config fields:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security
 
 * bump Pillow pin to `>=12.1.1,<13` to fix CVE-2026-25990 (PSD out-of-bounds write); previous pin `>=10.0,<12` blocked the fix ([#141](https://github.com/neuralsignal/obsidian-export/issues/141))
+* validate `heading_styles.size`, `title_style.size`, and `code_fontsize` against dangerous LaTeX macros and restrict `heading_styles.level` to a sectioning-command allowlist (`section`, `subsection`, `subsubsection`, `paragraph`, `subparagraph`) ([#148](https://github.com/neuralsignal/obsidian-export/issues/148))
 
 ## [0.5.2](https://github.com/neuralsignal/obsidian-export/compare/v0.5.1...v0.5.2) (2026-04-13)
 

--- a/obsidian_export/pipeline/latex_header.py
+++ b/obsidian_export/pipeline/latex_header.py
@@ -13,6 +13,8 @@ _DANGEROUS_LATEX_RE = re.compile(
     re.IGNORECASE,
 )
 
+_VALID_HEADING_LEVELS = frozenset({"section", "subsection", "subsubsection", "paragraph", "subparagraph"})
+
 
 def render_header(style: StyleConfig, template_path: Path, title: str) -> str:
     """Read header.tex template and substitute config values.
@@ -165,8 +167,14 @@ def _build_heading_styles_block(heading_styles: tuple[HeadingStyle, ...]) -> str
         return ""
     lines = ["\\usepackage{titlesec}"]
     for h in heading_styles:
+        if h.level not in _VALID_HEADING_LEVELS:
+            msg = (
+                f"Config field 'heading_styles.level' must be one of {sorted(_VALID_HEADING_LEVELS)}; got '{h.level}'."
+            )
+            raise UnsafeLatexError(msg)
+        _validate_latex_value(f"\\{h.size}", "heading_styles.size")
         parts = ["\\normalfont"]
-        parts.append(f"\\{_escape_latex(h.size)}")
+        parts.append(f"\\{h.size}")
         if h.bold:
             parts.append("\\bfseries")
         if h.sans:
@@ -176,8 +184,7 @@ def _build_heading_styles_block(heading_styles: tuple[HeadingStyle, ...]) -> str
         fmt = "".join(parts)
         # For the content argument (last {}), use \\MakeUppercase if uppercase
         content_arg = "{\\MakeUppercase}" if h.uppercase else "{}"
-        escaped_level = _escape_latex(h.level)
-        lines.append(f"\\titleformat{{\\{escaped_level}}}\n  {{{fmt}}}\n  {{\\the{escaped_level}}}{{1em}}{content_arg}")
+        lines.append(f"\\titleformat{{\\{h.level}}}\n  {{{fmt}}}\n  {{\\the{h.level}}}{{1em}}{content_arg}")
     return "\n\n".join(lines)
 
 
@@ -185,8 +192,9 @@ def _build_title_style_block(title_style: TitleStyle | None) -> str:
     """Generate custom \\maketitle definition."""
     if title_style is None:
         return ""
+    _validate_latex_value(f"\\{title_style.size}", "title_style.size")
     title_parts = []
-    title_parts.append(f"\\{_escape_latex(title_style.size)}")
+    title_parts.append(f"\\{title_style.size}")
     if title_style.bold:
         title_parts.append("\\bfseries")
     if title_style.sans:
@@ -215,6 +223,7 @@ def _build_title_style_block(title_style: TitleStyle | None) -> str:
 def _build_code_block(code_fontsize: str) -> str:
     """Generate fvextra setup for code block line-wrapping and font size control."""
     cmd = f"\\{code_fontsize}"
+    _validate_latex_value(cmd, "code_fontsize")
     return (
         "\\usepackage{fvextra}\n"
         f"\\fvset{{breaklines=true, fontsize={cmd}}}\n"

--- a/tests/test_latex_header.py
+++ b/tests/test_latex_header.py
@@ -204,6 +204,14 @@ class TestBuildCodeBlock:
         result = _build_code_block("footnotesize")
         assert "\\DefineVerbatimEnvironment{verbatim}" in result
 
+    def test_rejects_dangerous_macro(self) -> None:
+        with pytest.raises(UnsafeLatexError, match="code_fontsize"):
+            _build_code_block("write18")
+
+    def test_rejects_input_macro(self) -> None:
+        with pytest.raises(UnsafeLatexError, match="code_fontsize"):
+            _build_code_block("input{/etc/passwd}")
+
 
 class TestBuildLineSpacingBlock:
     def test_one_point_zero_returns_empty(self) -> None:
@@ -350,23 +358,33 @@ class TestBuildHeadingStylesBlock:
         assert "\\titleformat{\\subsection}" in result
         assert "\\titleformat{\\subsubsection}" in result
 
-    def test_injection_in_level_escaped(self) -> None:
+    def test_invalid_level_rejected(self) -> None:
         styles = (
             HeadingStyle(
                 level="section}\\write18{cmd", size="Large", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        result = _build_heading_styles_block(styles)
-        assert "\\write18" not in result
+        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+            _build_heading_styles_block(styles)
 
-    def test_injection_in_size_escaped(self) -> None:
+    def test_unknown_level_rejected(self) -> None:
+        styles = (HeadingStyle(level="write18", size="Large", bold=False, sans=False, color="", uppercase=False),)
+        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+            _build_heading_styles_block(styles)
+
+    def test_dangerous_macro_in_size_rejected(self) -> None:
+        styles = (HeadingStyle(level="section", size="write18", bold=False, sans=False, color="", uppercase=False),)
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_heading_styles_block(styles)
+
+    def test_injection_in_size_rejected(self) -> None:
         styles = (
             HeadingStyle(
                 level="section", size="Large}\\write18{cmd", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        result = _build_heading_styles_block(styles)
-        assert "\\write18" not in result
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_heading_styles_block(styles)
 
     def test_injection_in_color_escaped(self) -> None:
         styles = (
@@ -376,6 +394,12 @@ class TestBuildHeadingStylesBlock:
         )
         result = _build_heading_styles_block(styles)
         assert "\\write18" not in result
+
+    def test_valid_levels_accepted(self) -> None:
+        for level in ("section", "subsection", "subsubsection", "paragraph", "subparagraph"):
+            styles = (HeadingStyle(level=level, size="Large", bold=False, sans=False, color="", uppercase=False),)
+            result = _build_heading_styles_block(styles)
+            assert f"\\titleformat{{\\{level}}}" in result
 
 
 class TestBuildTitleStyleBlock:
@@ -408,10 +432,15 @@ class TestBuildTitleStyleBlock:
         result = _build_title_style_block(ts)
         assert "\\color{turkis}" in result
 
-    def test_injection_in_size_escaped(self) -> None:
+    def test_injection_in_size_rejected(self) -> None:
         ts = TitleStyle(size="huge}\\write18{cmd", bold=False, sans=False, color="", date_visible=False, vskip_after="")
-        result = _build_title_style_block(ts)
-        assert "\\write18" not in result
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_title_style_block(ts)
+
+    def test_dangerous_macro_in_size_rejected(self) -> None:
+        ts = TitleStyle(size="write18", bold=False, sans=False, color="", date_visible=False, vskip_after="")
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_title_style_block(ts)
 
     def test_injection_in_color_escaped(self) -> None:
         ts = TitleStyle(

--- a/tests/test_latex_header_blocks.py
+++ b/tests/test_latex_header_blocks.py
@@ -180,6 +180,14 @@ class TestBuildCodeBlock:
         result = _build_code_block("footnotesize")
         assert "\\DefineVerbatimEnvironment{verbatim}" in result
 
+    def test_rejects_dangerous_macro(self) -> None:
+        with pytest.raises(UnsafeLatexError, match="code_fontsize"):
+            _build_code_block("write18")
+
+    def test_rejects_input_macro(self) -> None:
+        with pytest.raises(UnsafeLatexError, match="code_fontsize"):
+            _build_code_block("input{/etc/passwd}")
+
 
 class TestBuildLineSpacingBlock:
     def test_one_point_zero_returns_empty(self) -> None:

--- a/tests/test_latex_header_styles.py
+++ b/tests/test_latex_header_styles.py
@@ -2,7 +2,10 @@
 
 import dataclasses
 
+import pytest
+
 from obsidian_export.config import HeadingStyle, StyleConfig, TitleStyle, default_config
+from obsidian_export.exceptions import UnsafeLatexError
 from obsidian_export.pipeline.latex_header import (
     _build_heading_styles_block,
     _build_title_style_block,
@@ -58,23 +61,33 @@ class TestBuildHeadingStylesBlock:
         assert "\\titleformat{\\subsection}" in result
         assert "\\titleformat{\\subsubsection}" in result
 
-    def test_injection_in_level_escaped(self) -> None:
+    def test_invalid_level_rejected(self) -> None:
         styles = (
             HeadingStyle(
                 level="section}\\write18{cmd", size="Large", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        result = _build_heading_styles_block(styles)
-        assert "\\write18" not in result
+        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+            _build_heading_styles_block(styles)
 
-    def test_injection_in_size_escaped(self) -> None:
+    def test_unknown_level_rejected(self) -> None:
+        styles = (HeadingStyle(level="write18", size="Large", bold=False, sans=False, color="", uppercase=False),)
+        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+            _build_heading_styles_block(styles)
+
+    def test_dangerous_macro_in_size_rejected(self) -> None:
+        styles = (HeadingStyle(level="section", size="write18", bold=False, sans=False, color="", uppercase=False),)
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_heading_styles_block(styles)
+
+    def test_injection_in_size_rejected(self) -> None:
         styles = (
             HeadingStyle(
                 level="section", size="Large}\\write18{cmd", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        result = _build_heading_styles_block(styles)
-        assert "\\write18" not in result
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_heading_styles_block(styles)
 
     def test_injection_in_color_escaped(self) -> None:
         styles = (
@@ -84,6 +97,12 @@ class TestBuildHeadingStylesBlock:
         )
         result = _build_heading_styles_block(styles)
         assert "\\write18" not in result
+
+    def test_valid_levels_accepted(self) -> None:
+        for level in ("section", "subsection", "subsubsection", "paragraph", "subparagraph"):
+            styles = (HeadingStyle(level=level, size="Large", bold=False, sans=False, color="", uppercase=False),)
+            result = _build_heading_styles_block(styles)
+            assert f"\\titleformat{{\\{level}}}" in result
 
 
 class TestBuildTitleStyleBlock:
@@ -116,10 +135,15 @@ class TestBuildTitleStyleBlock:
         result = _build_title_style_block(ts)
         assert "\\color{turkis}" in result
 
-    def test_injection_in_size_escaped(self) -> None:
+    def test_injection_in_size_rejected(self) -> None:
         ts = TitleStyle(size="huge}\\write18{cmd", bold=False, sans=False, color="", date_visible=False, vskip_after="")
-        result = _build_title_style_block(ts)
-        assert "\\write18" not in result
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_title_style_block(ts)
+
+    def test_dangerous_macro_in_size_rejected(self) -> None:
+        ts = TitleStyle(size="write18", bold=False, sans=False, color="", date_visible=False, vskip_after="")
+        with pytest.raises(UnsafeLatexError, match="dangerous LaTeX macro"):
+            _build_title_style_block(ts)
 
     def test_injection_in_color_escaped(self) -> None:
         ts = TitleStyle(


### PR DESCRIPTION
Closes #148

## Summary

Auto-implemented by Claude from issue #148.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)