### PR TITLE
[code-quality] _build_heading_styles_block raises UnsafeLatexError for

### DIFF
--- a/obsidian_export/pipeline/latex_header.py
+++ b/obsidian_export/pipeline/latex_header.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 from obsidian_export.config import HeadingStyle, StyleConfig, TitleStyle
-from obsidian_export.exceptions import UnsafeLatexError
+from obsidian_export.exceptions import ConfigValueError, UnsafeLatexError
 
 _DANGEROUS_LATEX_RE = re.compile(
     r"\\(?:input|include|write\d*|immediate|openin|openout|read|closein|closeout"
@@ -171,7 +171,7 @@ def _build_heading_styles_block(heading_styles: tuple[HeadingStyle, ...]) -> str
             msg = (
                 f"Config field 'heading_styles.level' must be one of {sorted(_VALID_HEADING_LEVELS)}; got '{h.level}'."
             )
-            raise UnsafeLatexError(msg)
+            raise ConfigValueError(msg)
         _validate_latex_value(f"\\{h.size}", "heading_styles.size")
         parts = ["\\normalfont"]
         parts.append(f"\\{h.size}")

--- a/tests/test_latex_header.py
+++ b/tests/test_latex_header.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from obsidian_export.config import CalloutColors, HeadingStyle, StyleConfig, TitleStyle, default_config
-from obsidian_export.exceptions import UnsafeLatexError
+from obsidian_export.exceptions import ConfigValueError, UnsafeLatexError
 from obsidian_export.pipeline.latex_header import (
     _build_brand_colors_block,
     _build_code_block,
@@ -364,12 +364,12 @@ class TestBuildHeadingStylesBlock:
                 level="section}\\write18{cmd", size="Large", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_unknown_level_rejected(self) -> None:
         styles = (HeadingStyle(level="write18", size="Large", bold=False, sans=False, color="", uppercase=False),)
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_dangerous_macro_in_size_rejected(self) -> None:

--- a/tests/test_latex_header_styles.py
+++ b/tests/test_latex_header_styles.py
@@ -5,7 +5,7 @@ import dataclasses
 import pytest
 
 from obsidian_export.config import HeadingStyle, StyleConfig, TitleStyle, default_config
-from obsidian_export.exceptions import UnsafeLatexError
+from obsidian_export.exceptions import ConfigValueError, UnsafeLatexError
 from obsidian_export.pipeline.latex_header import (
     _build_heading_styles_block,
     _build_title_style_block,
@@ -67,12 +67,12 @@ class TestBuildHeadingStylesBlock:
                 level="section}\\write18{cmd", size="Large", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_unknown_level_rejected(self) -> None:
         styles = (HeadingStyle(level="write18", size="Large", bold=False, sans=False, color="", uppercase=False),)
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_dangerous_macro_in_size_rejected(self) -> None:


### PR DESCRIPTION
Closes #174

## Summary

Auto-implemented by Claude from issue #174.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)