### PR TITLE
[code-quality] config/__init__.py exposes internal parser helpers in _

### DIFF
--- a/obsidian_export/config/__init__.py
+++ b/obsidian_export/config/__init__.py
@@ -6,15 +6,9 @@ Re-exports all public names so that
 
 from obsidian_export.config.loader import (
     build_config,
-    deep_merge,
     default_config,
     load_config,
     load_default_yaml,
-    parse_brand_colors,
-    parse_heading_styles,
-    parse_title_style,
-    parse_unicode_chars,
-    resolve_path,
 )
 from obsidian_export.config.models import (
     CalloutColors,
@@ -42,15 +36,9 @@ __all__ = [
     "StyleConfig",
     "TitleStyle",
     "build_config",
-    "deep_merge",
     "default_config",
     "load_config",
     "load_default_yaml",
-    "parse_brand_colors",
-    "parse_heading_styles",
-    "parse_title_style",
-    "parse_unicode_chars",
-    "resolve_path",
     "validate_from_format",
     "validate_pandoc_variable",
     "validate_url_strategy",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,16 +17,18 @@ from obsidian_export.config import (
     StyleConfig,
     TitleStyle,
     build_config,
-    deep_merge,
     default_config,
     load_config,
+    validate_from_format,
+    validate_pandoc_variable,
+)
+from obsidian_export.config.loader import (
+    deep_merge,
     parse_brand_colors,
     parse_heading_styles,
     parse_title_style,
     parse_unicode_chars,
     resolve_path,
-    validate_from_format,
-    validate_pandoc_variable,
 )
 from obsidian_export.exceptions import ConfigValueError
 

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -8,10 +8,10 @@ from conftest import VALID_DATA, write_config
 from obsidian_export.config import (
     HeadingStyle,
     TitleStyle,
-    deep_merge,
     default_config,
     load_config,
 )
+from obsidian_export.config.loader import deep_merge
 
 # ── deep merge ──────────────────────────────────────────────────────────────
 

--- a/tests/test_config_parsers.py
+++ b/tests/test_config_parsers.py
@@ -8,6 +8,8 @@ from hypothesis import strategies as st
 from obsidian_export.config import (
     HeadingStyle,
     TitleStyle,
+)
+from obsidian_export.config.loader import (
     parse_brand_colors,
     parse_heading_styles,
     parse_title_style,


### PR DESCRIPTION
Closes #179

## Summary

Auto-implemented by Claude from issue #179.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)