### PR TITLE
Merge open code-quality PRs (#175, #176, #180, #181)

### DIFF
--- a/obsidian_export/config/__init__.py
+++ b/obsidian_export/config/__init__.py
@@ -6,15 +6,9 @@ Re-exports all public names so that
 
 from obsidian_export.config.loader import (
     build_config,
-    deep_merge,
     default_config,
     load_config,
     load_default_yaml,
-    parse_brand_colors,
-    parse_heading_styles,
-    parse_title_style,
-    parse_unicode_chars,
-    resolve_path,
 )
 from obsidian_export.config.models import (
     CalloutColors,
@@ -42,15 +36,9 @@ __all__ = [
     "StyleConfig",
     "TitleStyle",
     "build_config",
-    "deep_merge",
     "default_config",
     "load_config",
     "load_default_yaml",
-    "parse_brand_colors",
-    "parse_heading_styles",
-    "parse_title_style",
-    "parse_unicode_chars",
-    "resolve_path",
     "validate_from_format",
     "validate_pandoc_variable",
     "validate_url_strategy",

--- a/obsidian_export/pipeline/image_convert.py
+++ b/obsidian_export/pipeline/image_convert.py
@@ -2,27 +2,35 @@
 
 import re
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from obsidian_export.exceptions import ObsidianExportError
 from obsidian_export.pipeline.path_guards import assert_within_root
 
 
+@dataclass(frozen=True)
+class ImageConversionSpec:
+    """Groups format-specific parameters for image reference conversion."""
+
+    pattern: re.Pattern[str]
+    convert_fn: Callable[[Path, Path], None]
+    out_prefix: str
+    out_ext: str
+    label: str
+    not_found_error: type[ObsidianExportError]
+    pre_filter: Callable[[re.Match[str]], str | None]
+
+
 def convert_image_references(
     body: str,
     tmpdir: Path,
     resource_path: Path | None,
-    pattern: re.Pattern[str],
-    convert_fn: Callable[[Path, Path], None],
-    out_prefix: str,
-    out_ext: str,
-    label: str,
-    not_found_error: type[ObsidianExportError],
-    pre_filter: Callable[[re.Match[str]], str | None],
+    spec: ImageConversionSpec,
 ) -> str:
-    """Scan body for image references matching pattern and convert each via convert_fn.
+    """Scan body for image references matching spec.pattern and convert each.
 
-    pre_filter receives each non-URL match before path resolution. Return a
+    spec.pre_filter receives each non-URL match before path resolution. Return a
     string to use as the replacement (skipping conversion), or None to proceed
     with the standard resolve-guard-convert flow.
     """
@@ -36,7 +44,7 @@ def convert_image_references(
         if img_raw.startswith(("http://", "https://")):
             return m.group(0)
 
-        filtered = pre_filter(m)
+        filtered = spec.pre_filter(m)
         if filtered is not None:
             return filtered
 
@@ -46,16 +54,16 @@ def convert_image_references(
             img_path = resource_path / img_path
 
         if resource_path is not None:
-            assert_within_root(img_path, resource_path, label)
+            assert_within_root(img_path, resource_path, spec.label)
 
         if not img_path.exists():
-            raise not_found_error(f"{label} file not found: {img_path}")
+            raise spec.not_found_error(f"{spec.label} file not found: {img_path}")
 
         counter += 1
-        out_path = tmpdir / f"{out_prefix}{counter}{out_ext}"
+        out_path = tmpdir / f"{spec.out_prefix}{counter}{spec.out_ext}"
 
-        convert_fn(img_path, out_path)
+        spec.convert_fn(img_path, out_path)
 
         return f"![{alt_text}]({out_path})"
 
-    return pattern.sub(replace_match, body)
+    return spec.pattern.sub(replace_match, body)

--- a/obsidian_export/pipeline/latex_header.py
+++ b/obsidian_export/pipeline/latex_header.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 from obsidian_export.config import HeadingStyle, StyleConfig, TitleStyle
-from obsidian_export.exceptions import UnsafeLatexError
+from obsidian_export.exceptions import ConfigValueError, UnsafeLatexError
 
 _DANGEROUS_LATEX_RE = re.compile(
     r"\\(?:input|include|write\d*|immediate|openin|openout|read|closein|closeout"
@@ -171,7 +171,7 @@ def _build_heading_styles_block(heading_styles: tuple[HeadingStyle, ...]) -> str
             msg = (
                 f"Config field 'heading_styles.level' must be one of {sorted(_VALID_HEADING_LEVELS)}; got '{h.level}'."
             )
-            raise UnsafeLatexError(msg)
+            raise ConfigValueError(msg)
         _validate_latex_value(f"\\{h.size}", "heading_styles.size")
         parts = ["\\normalfont"]
         parts.append(f"\\{h.size}")

--- a/obsidian_export/pipeline/stage2_preprocess.py
+++ b/obsidian_export/pipeline/stage2_preprocess.py
@@ -110,7 +110,8 @@ def process_urls(text: str, strategy: str, threshold: int) -> str:
         url = m.group(1)
         if strategy == "footnote_all" or (strategy == "footnote_long" and len(url) > threshold):
             # Pandoc footnote syntax: [^N] — but inline footnotes are cleaner
-            return f"[link]({url})[^url-{abs(hash(url)) % 100000}]\n\n[^url-{abs(hash(url)) % 100000}]: <{url}>"
+            footnote_id = abs(hash(url)) % 100000
+            return f"[link]({url})[^url-{footnote_id}]\n\n[^url-{footnote_id}]: <{url}>"
         return m.group(0)
 
     if strategy == "strip":

--- a/obsidian_export/pipeline/stage3_image.py
+++ b/obsidian_export/pipeline/stage3_image.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from PIL import Image
 
 from obsidian_export.exceptions import ImageConversionError
-from obsidian_export.pipeline.image_convert import convert_image_references
+from obsidian_export.pipeline.image_convert import ImageConversionSpec, convert_image_references
 from obsidian_export.pipeline.path_guards import assert_within_root
 
 PDF_NATIVE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".pdf"})
@@ -67,18 +67,16 @@ def convert_images(
                 f"Failed to convert {src} to PNG: {exc}. Ensure Pillow supports the {ext} format."
             ) from exc
 
-    return convert_image_references(
-        body,
-        tmpdir,
-        resource_path,
-        _IMG_REF_RE,
-        _do_convert,
-        "img_",
-        ".png",
-        "Image",
-        ImageConversionError,
-        _pre_filter,
+    spec = ImageConversionSpec(
+        pattern=_IMG_REF_RE,
+        convert_fn=_do_convert,
+        out_prefix="img_",
+        out_ext=".png",
+        label="Image",
+        not_found_error=ImageConversionError,
+        pre_filter=_pre_filter,
     )
+    return convert_image_references(body, tmpdir, resource_path, spec)
 
 
 def convert_images_for_pdf(

--- a/obsidian_export/pipeline/stage3_svg.py
+++ b/obsidian_export/pipeline/stage3_svg.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 
 from obsidian_export.exceptions import SVGConversionError
-from obsidian_export.pipeline.image_convert import convert_image_references
+from obsidian_export.pipeline.image_convert import ImageConversionSpec, convert_image_references
 
 _IMG_REF_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+\.svg)\)")
 
@@ -36,18 +36,16 @@ def _convert_svg_images(body: str, tmpdir: Path, resource_path: Path | None, rsv
             stderr = exc.stderr.decode(errors="replace") if exc.stderr else "(no stderr)"
             raise SVGConversionError(f"rsvg-convert failed for {src} (exit {exc.returncode}): {stderr}") from exc
 
-    return convert_image_references(
-        body,
-        tmpdir,
-        resource_path,
-        _IMG_REF_RE,
-        _do_convert,
-        "svg_",
-        file_ext,
-        "SVG",
-        SVGConversionError,
-        lambda _m: None,
+    spec = ImageConversionSpec(
+        pattern=_IMG_REF_RE,
+        convert_fn=_do_convert,
+        out_prefix="svg_",
+        out_ext=file_ext,
+        label="SVG",
+        not_found_error=SVGConversionError,
+        pre_filter=lambda _m: None,
     )
+    return convert_image_references(body, tmpdir, resource_path, spec)
 
 
 def convert_svg_images(body: str, tmpdir: Path, resource_path: Path | None) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,16 +17,18 @@ from obsidian_export.config import (
     StyleConfig,
     TitleStyle,
     build_config,
-    deep_merge,
     default_config,
     load_config,
+    validate_from_format,
+    validate_pandoc_variable,
+)
+from obsidian_export.config.loader import (
+    deep_merge,
     parse_brand_colors,
     parse_heading_styles,
     parse_title_style,
     parse_unicode_chars,
     resolve_path,
-    validate_from_format,
-    validate_pandoc_variable,
 )
 from obsidian_export.exceptions import ConfigValueError
 

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -8,10 +8,10 @@ from conftest import VALID_DATA, write_config
 from obsidian_export.config import (
     HeadingStyle,
     TitleStyle,
-    deep_merge,
     default_config,
     load_config,
 )
+from obsidian_export.config.loader import deep_merge
 
 # ── deep merge ──────────────────────────────────────────────────────────────
 

--- a/tests/test_config_parsers.py
+++ b/tests/test_config_parsers.py
@@ -8,6 +8,8 @@ from hypothesis import strategies as st
 from obsidian_export.config import (
     HeadingStyle,
     TitleStyle,
+)
+from obsidian_export.config.loader import (
     parse_brand_colors,
     parse_heading_styles,
     parse_title_style,

--- a/tests/test_latex_header.py
+++ b/tests/test_latex_header.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from obsidian_export.config import CalloutColors, HeadingStyle, StyleConfig, TitleStyle, default_config
-from obsidian_export.exceptions import UnsafeLatexError
+from obsidian_export.exceptions import ConfigValueError, UnsafeLatexError
 from obsidian_export.pipeline.latex_header import (
     _build_brand_colors_block,
     _build_code_block,
@@ -364,12 +364,12 @@ class TestBuildHeadingStylesBlock:
                 level="section}\\write18{cmd", size="Large", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_unknown_level_rejected(self) -> None:
         styles = (HeadingStyle(level="write18", size="Large", bold=False, sans=False, color="", uppercase=False),)
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_dangerous_macro_in_size_rejected(self) -> None:

--- a/tests/test_latex_header_styles.py
+++ b/tests/test_latex_header_styles.py
@@ -5,7 +5,7 @@ import dataclasses
 import pytest
 
 from obsidian_export.config import HeadingStyle, StyleConfig, TitleStyle, default_config
-from obsidian_export.exceptions import UnsafeLatexError
+from obsidian_export.exceptions import ConfigValueError, UnsafeLatexError
 from obsidian_export.pipeline.latex_header import (
     _build_heading_styles_block,
     _build_title_style_block,
@@ -67,12 +67,12 @@ class TestBuildHeadingStylesBlock:
                 level="section}\\write18{cmd", size="Large", bold=False, sans=False, color="", uppercase=False
             ),
         )
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_unknown_level_rejected(self) -> None:
         styles = (HeadingStyle(level="write18", size="Large", bold=False, sans=False, color="", uppercase=False),)
-        with pytest.raises(UnsafeLatexError, match="heading_styles.level"):
+        with pytest.raises(ConfigValueError, match="heading_styles.level"):
             _build_heading_styles_block(styles)
 
     def test_dangerous_macro_in_size_rejected(self) -> None:


### PR DESCRIPTION
## Summary

Combines the four open code-quality PRs into a single master PR. All four touch disjoint files and merged cleanly with no conflicts.

Bundled PRs:
- #175 — `_build_heading_styles_block` raises `ConfigValueError` (not `UnsafeLatexError`) for invalid `heading_styles.level` (issue #174)
- #176 — refactor `convert_image_references` to take an `ImageConversionSpec` dataclass, reducing the 10-parameter signature (issue #172)
- #180 — extract duplicated `abs(hash(url)) % 100000` expression in `process_urls` footnote branch (issue #178)
- #181 — drop internal parser helpers (`deep_merge`, `parse_*`, `resolve_path`) from `obsidian_export.config` public API; tests import them from `obsidian_export.config.loader` (issue #179)

## Files changed

| File | From PR |
|---|---|
| `obsidian_export/config/__init__.py` | #181 |
| `obsidian_export/pipeline/image_convert.py` | #176 |
| `obsidian_export/pipeline/latex_header.py` | #175 |
| `obsidian_export/pipeline/stage2_preprocess.py` | #180 |
| `obsidian_export/pipeline/stage3_image.py` | #176 |
| `obsidian_export/pipeline/stage3_svg.py` | #176 |
| `tests/test_config.py` | #181 |
| `tests/test_config_merge.py` | #181 |
| `tests/test_config_parsers.py` | #181 |
| `tests/test_latex_header.py` | #175 |
| `tests/test_latex_header_styles.py` | #175 |

Combined diff: 11 files, +61 / −64.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] All touched modules compile (`python -m py_compile`)
- [ ] CI runs the full `pixi run test-cov` suite (test deps not installable in local sandbox)
- [ ] After merge, close PRs #175, #176, #180, #181 as superseded

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxgG8ZuVNs2FUP3iQFoKur)_