### PR TITLE
[security-scan] native-format absolute image paths bypass assert_withi

### DIFF
--- a/obsidian_export/pipeline/stage3_image.py
+++ b/obsidian_export/pipeline/stage3_image.py
@@ -53,6 +53,10 @@ def convert_images(
                 abs_path = resource_path / img_path
                 assert_within_root(abs_path, resource_path, "Image")
                 return f"![{m.group(1)}]({abs_path})"
+            if img_path.is_absolute() and resource_path is not None:
+                resolved = img_path.resolve()
+                if not resolved.is_relative_to(tmpdir.resolve()):
+                    assert_within_root(img_path, resource_path, "Image")
             return m.group(0)
 
         return None

--- a/tests/test_stage3_image_conversion.py
+++ b/tests/test_stage3_image_conversion.py
@@ -276,6 +276,49 @@ class TestPathTraversal:
             with pytest.raises(PathTraversalError, match="Image path escapes document root"):
                 convert_images_for_pdf(text, tmpdir, resource_path=vault)
 
+    def test_native_absolute_path_outside_root_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as workdir:
+            workdir = Path(workdir)
+            vault = workdir / "vault"
+            vault.mkdir()
+            outside = workdir / "outside.png"
+            _create_test_image(outside, "PNG")
+
+            tmpdir = workdir / "out"
+            tmpdir.mkdir()
+
+            text = f"![escape]({outside})\n"
+            with pytest.raises(PathTraversalError, match="Image path escapes document root"):
+                convert_images_for_pdf(text, tmpdir, resource_path=vault)
+
+    def test_native_absolute_path_within_root_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as workdir:
+            workdir = Path(workdir)
+            vault = workdir / "vault"
+            vault.mkdir()
+            img = vault / "photo.png"
+            _create_test_image(img, "PNG")
+
+            tmpdir = workdir / "out"
+            tmpdir.mkdir()
+
+            text = f"![ok]({img})\n"
+            result = convert_images_for_pdf(text, tmpdir, resource_path=vault)
+            assert str(img) in result
+
+    def test_native_absolute_path_no_resource_path_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as workdir:
+            workdir = Path(workdir)
+            img = workdir / "photo.png"
+            _create_test_image(img, "PNG")
+
+            tmpdir = workdir / "out"
+            tmpdir.mkdir()
+
+            text = f"![ok]({img})\n"
+            result = convert_images_for_pdf(text, tmpdir, resource_path=None)
+            assert str(img) in result
+
     def test_path_within_root_allowed(self) -> None:
         with tempfile.TemporaryDirectory() as workdir:
             workdir = Path(workdir)


### PR DESCRIPTION
Closes #246

## Summary

Auto-implemented by Claude from issue #246.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)