### PR TITLE
docs: sync documentation with codebase

### DIFF
--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -19,6 +19,7 @@ Handles Obsidian-specific vault operations:
 
 - **Frontmatter parsing** — extracts YAML frontmatter, cleans tags into keywords
 - **Title extraction** — uses frontmatter `title` or falls back to filename stem
+- **Title deduplication** — strips the leading H1 heading if it matches the document title (prevents duplicate titles in output)
 - **Embed resolution** — recursively resolves `![[embed]]` references with circular reference detection
 - **Syntax stripping** — converts `[[wikilinks]]` to plain text, removes `## Relations` sections
 


### PR DESCRIPTION
## Summary

Automated documentation update triggered by source code changes.

## What changed

Documentation pages in `docs/` were updated to match the current state of the codebase.

## Test plan

- [ ] `mkdocs build --strict` passes
- [ ] All nav links resolve
- [ ] API reference reflects current code
